### PR TITLE
fix: do not send cluster or sensor id if not selected in form

### DIFF
--- a/frontend/src/components/tree/TreeUpdate.tsx
+++ b/frontend/src/components/tree/TreeUpdate.tsx
@@ -57,9 +57,9 @@ const TreeUpdate = ({ treeId, onUpdateSuccess, onUpdateError }: TreeUpdateProps)
     mutate({
       ...data,
       description: data.description ?? '',
-      sensorId: data.sensorId === '-1' ? undefined : data.sensorId,
+      sensorId: data.sensorId && (data.sensorId === '-1' || data.sensorId <= 0) ? undefined : data.sensorId,
       treeClusterId:
-        data.treeClusterId === '-1' ? undefined : data.treeClusterId,
+        data.treeClusterId && (data.treeClusterId === '-1' || data.treeClusterId <= 0) ? undefined : data.treeClusterId,
       readonly: false,
     })
   }

--- a/frontend/src/routes/_protected/tree/_formular/new.tsx
+++ b/frontend/src/routes/_protected/tree/_formular/new.tsx
@@ -84,9 +84,9 @@ function NewTree() {
   const onSubmit = (data: TreeForm) => {
     mutate({
       ...data,
-      sensorId: data.sensorId === '-1' ? undefined : data.sensorId,
+      sensorId: data.sensorId && (data.sensorId === '-1' || data.sensorId <= 0) ? undefined : data.sensorId,
       treeClusterId:
-        data.treeClusterId === '-1' ? undefined : data.treeClusterId,
+        data.treeClusterId && (data.treeClusterId === '-1' || data.treeClusterId <= 0) ? undefined : data.treeClusterId,
       description: data.description ?? '',
       readonly: false,
     })


### PR DESCRIPTION
In the context of green-ecolution/green-ecolution-backend#123