### PR TITLE
fix: do not filter treecluster without region or show them on map

### DIFF
--- a/frontend/src/api/backendApi.ts
+++ b/frontend/src/api/backendApi.ts
@@ -40,7 +40,7 @@ const backendFetch: FetchAPI = async (...args) => {
     }
     const data = ClientTokenFromJSON(await res.json())
     useStore.getState().auth.setToken(data)
-    useStore.getState().user.setFromJwt(data.accessToken);
+    useStore.getState().user.setFromJwt(data.accessToken)
 
     response = await fetch(resource, {
       ...config,

--- a/frontend/src/components/map/TreeMarker.tsx
+++ b/frontend/src/components/map/TreeMarker.tsx
@@ -84,25 +84,22 @@ export const WithAllClusters = ({
     return hasHighlightedCluster === clusterId
   }
 
-  // Do not show tree clusters on the map that do not have a region
-  const filterEmptyClusters = (clusters: TreeCluster[]) => {
-    return clusters.filter(cluster => cluster.region !== undefined);
-  }
-
-  return filterEmptyClusters(clusters).map((cluster) => (
-    <Marker
-      icon={ClusterIcon(
-        getStatusColor(cluster.wateringStatus),
-        isHighlighted(cluster.id),
-        cluster.trees?.length ?? 0
-      )}
-      key={cluster.id}
-      position={[cluster.latitude, cluster.longitude]}
-      eventHandlers={{
-        click: () => onClick?.(cluster),
-      }}
-    />
-  ))
+  return clusters
+    .filter((cluster) => cluster.region !== undefined)
+    .map((cluster) => (
+      <Marker
+        icon={ClusterIcon(
+          getStatusColor(cluster.wateringStatus),
+          isHighlighted(cluster.id),
+          cluster.trees?.length ?? 0
+        )}
+        key={cluster.id}
+        position={[cluster.latitude, cluster.longitude]}
+        eventHandlers={{
+          click: () => onClick?.(cluster),
+        }}
+      />
+    ))
 }
 
 interface WithTreesAndClustersProps {

--- a/frontend/src/components/map/TreeMarker.tsx
+++ b/frontend/src/components/map/TreeMarker.tsx
@@ -84,7 +84,12 @@ export const WithAllClusters = ({
     return hasHighlightedCluster === clusterId
   }
 
-  return clusters.map((cluster) => (
+  // Do not show tree clusters on the map that do not have a region
+  const filterEmptyClusters = (clusters: TreeCluster[]) => {
+    return clusters.filter(cluster => cluster.region !== undefined);
+  }
+
+  return filterEmptyClusters(clusters).map((cluster) => (
     <Marker
       icon={ClusterIcon(
         getStatusColor(cluster.wateringStatus),

--- a/frontend/src/hooks/useMapInteractions.ts
+++ b/frontend/src/hooks/useMapInteractions.ts
@@ -1,19 +1,19 @@
-import { useMap } from "react-leaflet";
+import { useMap } from 'react-leaflet'
 
 function useMapInteractions() {
-  const map = useMap();
+  const map = useMap()
 
   const enableDragging = () => {
-    map.dragging.enable();
-    map.scrollWheelZoom.enable();
-  };
+    map.dragging.enable()
+    map.scrollWheelZoom.enable()
+  }
 
   const disableDragging = () => {
-    map.dragging.disable();
-    map.scrollWheelZoom.disable();
-  };
+    map.dragging.disable()
+    map.scrollWheelZoom.disable()
+  }
 
-  return { enableDragging, disableDragging };
+  return { enableDragging, disableDragging }
 }
 
-export default useMapInteractions;
+export default useMapInteractions

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -19,7 +19,7 @@ export const Route = createRootRoute({
     }
     useStore.getState().auth.setToken(token)
     useStore.getState().user.setFromJwt(token.accessToken)
-  }
+  },
 })
 
 function Root() {

--- a/frontend/src/routes/_protected/treecluster/index.tsx
+++ b/frontend/src/routes/_protected/treecluster/index.tsx
@@ -35,8 +35,7 @@ function Treecluster() {
 
       const regionFilter =
         filters.regionTags.length === 0 ||
-        (cluster.region !== undefined &&
-        filters.regionTags.includes(cluster.region.name))
+        (cluster.region && filters.regionTags.includes(cluster.region.name))
 
       return statusFilter && regionFilter
     })

--- a/frontend/src/routes/_protected/treecluster/index.tsx
+++ b/frontend/src/routes/_protected/treecluster/index.tsx
@@ -35,7 +35,8 @@ function Treecluster() {
 
       const regionFilter =
         filters.regionTags.length === 0 ||
-        filters.regionTags.includes(cluster.region.name)
+        (cluster.region !== undefined &&
+        filters.regionTags.includes(cluster.region.name))
 
       return statusFilter && regionFilter
     })

--- a/frontend/src/routes/auth/callback.tsx
+++ b/frontend/src/routes/auth/callback.tsx
@@ -1,6 +1,4 @@
 import { userApi } from "@/api/backendApi";
-import { KeycloakJWT } from "@/lib/types/keycloak";
-import { decodeJWT } from "@/lib/utils";
 import useStore from "@/store/store";
 import {
   createFileRoute,


### PR DESCRIPTION
Close #188 


How to test it:
1. Create a tree cluster that has no trees (even on error the tree cluster is currently created)
2. Navigate to the map and check that the treecluster is NOT displayed and the map should not crash anymore
3. Navigate to the index page of all treeclusters and filter them by region. The filter should not crash anymore