### PR TITLE
fix: show treecluster on filter without any options

### DIFF
--- a/frontend/src/routes/_protected/map/index.tsx
+++ b/frontend/src/routes/_protected/map/index.tsx
@@ -24,6 +24,8 @@ const mapFilterSchema = z.object({
   hasCluster: z.boolean().optional(),
   plantingYears: z.array(z.number()).optional(),
   highlighted: z.number().optional(),
+  tree: z.number().optional(),
+  cluster: z.number().optional(),
 })
 
 function MapView() {
@@ -81,7 +83,15 @@ function MapView() {
 
   const handleFilter = () => {
     const data = filterData()
-    setActiveFilter(true)
+    if (
+      filters.statusTags.length > 0 ||
+      filters.hasCluster !== undefined ||
+      filters.plantingYears.length > 0
+    ) {
+      setActiveFilter(true)
+    } else {
+      setActiveFilter(false)
+    }
     setFilteredData(data)
   }
 
@@ -142,7 +152,9 @@ export const Route = createFileRoute('/_protected/map/')({
   component: MapViewWithProvider,
   validateSearch: mapFilterSchema,
 
-  loaderDeps: ({ search: { status, hasCluster, plantingYears, tree, cluster } }) => ({
+  loaderDeps: ({
+    search: { status, hasCluster, plantingYears, tree, cluster },
+  }) => ({
     status: status || [],
     hasCluster: hasCluster || undefined,
     plantingYears: plantingYears || [],


### PR DESCRIPTION
Close #193 

How to test it:
1. Navigate to map
2. Open a filter and do not select anything
3. Close it without selecting any options
4. Show of the treecluster are displayed and not the trees