### PR TITLE
fix: disable map zoom on double click on filter option

### DIFF
--- a/frontend/src/hooks/useMapInteractions.ts
+++ b/frontend/src/hooks/useMapInteractions.ts
@@ -6,11 +6,13 @@ function useMapInteractions() {
   const enableDragging = () => {
     map.dragging.enable()
     map.scrollWheelZoom.enable()
+    map.doubleClickZoom.enable()
   }
 
   const disableDragging = () => {
     map.dragging.disable()
     map.scrollWheelZoom.disable()
+    map.doubleClickZoom.disable()
   }
 
   return { enableDragging, disableDragging }


### PR DESCRIPTION
Close #216 