### PR TITLE
feat: add pagination component to treecluster

### DIFF
--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -24,10 +24,10 @@ import {
   GeoJson,
 } from './backendApi'
 
-export const treeClusterQuery = () =>
+export const treeClusterQuery = (params?: { page?: string, limit?: string }) =>
   queryOptions<TreeClusterList>({
-    queryKey: ['treeclusters'],
-    queryFn: () => clusterApi.getAllTreeClusters(),
+    queryKey: ['treeclusters', params?.page ?? '1', params?.limit ?? 'none'],
+    queryFn: () => clusterApi.getAllTreeClusters(params),
   })
 
 export const treeClusterIdQuery = (id: string) =>

--- a/frontend/src/components/general/Pagination.tsx
+++ b/frontend/src/components/general/Pagination.tsx
@@ -1,0 +1,122 @@
+import { Pagination as PaginationObject } from '@green-ecolution/backend-client'
+import React from 'react'
+import PaginationLink from './links/PaginationLink'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+
+interface PaginationProps {
+  pagination: PaginationObject
+}
+
+const Pagination: React.FC<PaginationProps> = ({ pagination }) => {
+  return (
+    <nav aria-label="Seiten-Paginierung" className="mt-10">
+      <ul className="flex flex-wrap items-center justify-center gap-x-2">
+        <li>
+          <PaginationLink
+            aria-label="Vorherige Seite anzeigen"
+            color="green-dark"
+            disabled={pagination.currentPage - 1 == 0}
+            icon={ChevronLeft}
+            link={{
+              to: '/treecluster',
+              search: {
+                page: pagination.currentPage - 1,
+              },
+            }}
+          />
+        </li>
+        {pagination.prevPage > 1 && (
+          <li className="flex items-end gap-x-2">
+            <PaginationLink
+              aria-label="Zur ersten Seite springen"
+              color="grey"
+              label={1}
+              link={{
+                to: '/treecluster',
+                search: {
+                  page: 1,
+                },
+              }}
+            />
+            <span aria-hidden="true" className="text-dark-600 font-semibold">...</span>
+          </li>
+        )}
+        {pagination.prevPage && (
+          <li>
+            <PaginationLink
+              aria-label={`Zur vorherigen Seite ${pagination.prevPage} springen`}
+              color="grey"
+              label={pagination.prevPage}
+              link={{
+                to: '/treecluster',
+                search: {
+                  page: pagination.prevPage,
+                },
+              }}
+            />
+          </li>
+        )}
+        <li>
+          <PaginationLink
+            aria-label={`Aktuelle Seite ${pagination.prevPage}`}
+            color="green-light"
+            label={pagination.currentPage}
+            link={{
+              to: '/treecluster',
+              search: {
+                page: pagination.currentPage,
+              },
+            }}
+          />
+        </li>
+        {pagination.nextPage && (
+          <li>
+            <PaginationLink
+              aria-label={`Zur nächsten Seite ${pagination.nextPage} springen`}
+              color="grey"
+              label={pagination.nextPage}
+              link={{
+                to: '/treecluster',
+                search: {
+                  page: pagination.nextPage,
+                },
+              }}
+            />
+          </li>
+        )}
+        {pagination.nextPage && pagination.nextPage < pagination.totalPages && (
+          <li className="flex items-end gap-x-2">
+            <span aria-hidden="true" className="text-dark-600 font-semibold">...</span>
+            <PaginationLink
+              aria-label="Zur letzten Seite springen"
+              color="grey"
+              label={pagination.totalPages}
+              link={{
+                to: '/treecluster',
+                search: {
+                  page: pagination.totalPages,
+                },
+              }}
+            />
+          </li>
+        )}
+        <li>
+          <PaginationLink
+            aria-label="Vorherige Seite anzeigen"
+            color="green-dark"
+            disabled={pagination.currentPage == pagination.totalPages}
+            icon={ChevronRight}
+            link={{
+              to: '/treecluster',
+              search: {
+                page: pagination.currentPage + 1,
+              },
+            }}
+          />
+        </li>
+      </ul>
+    </nav>
+  )
+}
+
+export default Pagination

--- a/frontend/src/components/general/Pagination.tsx
+++ b/frontend/src/components/general/Pagination.tsx
@@ -5,9 +5,10 @@ import { ChevronLeft, ChevronRight } from 'lucide-react'
 
 interface PaginationProps {
   pagination: PaginationObject
+  url: string
 }
 
-const Pagination: React.FC<PaginationProps> = ({ pagination }) => {
+const Pagination: React.FC<PaginationProps> = ({ pagination, url }) => {
   return (
     <nav aria-label="Seiten-Paginierung" className="mt-10">
       <ul className="flex flex-wrap items-center justify-center gap-x-2">
@@ -18,7 +19,7 @@ const Pagination: React.FC<PaginationProps> = ({ pagination }) => {
             disabled={pagination.currentPage - 1 == 0}
             icon={ChevronLeft}
             link={{
-              to: '/treecluster',
+              to: url,
               search: {
                 page: pagination.currentPage - 1,
               },
@@ -32,7 +33,7 @@ const Pagination: React.FC<PaginationProps> = ({ pagination }) => {
               color="grey"
               label={1}
               link={{
-                to: '/treecluster',
+                to: url,
                 search: {
                   page: 1,
                 },
@@ -48,7 +49,7 @@ const Pagination: React.FC<PaginationProps> = ({ pagination }) => {
               color="grey"
               label={pagination.prevPage}
               link={{
-                to: '/treecluster',
+                to: url,
                 search: {
                   page: pagination.prevPage,
                 },
@@ -62,7 +63,7 @@ const Pagination: React.FC<PaginationProps> = ({ pagination }) => {
             color="green-light"
             label={pagination.currentPage}
             link={{
-              to: '/treecluster',
+              to: url,
               search: {
                 page: pagination.currentPage,
               },
@@ -76,7 +77,7 @@ const Pagination: React.FC<PaginationProps> = ({ pagination }) => {
               color="grey"
               label={pagination.nextPage}
               link={{
-                to: '/treecluster',
+                to: url,
                 search: {
                   page: pagination.nextPage,
                 },
@@ -92,7 +93,7 @@ const Pagination: React.FC<PaginationProps> = ({ pagination }) => {
               color="grey"
               label={pagination.totalPages}
               link={{
-                to: '/treecluster',
+                to: url,
                 search: {
                   page: pagination.totalPages,
                 },
@@ -107,7 +108,7 @@ const Pagination: React.FC<PaginationProps> = ({ pagination }) => {
             disabled={pagination.currentPage == pagination.totalPages}
             icon={ChevronRight}
             link={{
-              to: '/treecluster',
+              to: url,
               search: {
                 page: pagination.currentPage + 1,
               },

--- a/frontend/src/components/general/links/PaginationLink.tsx
+++ b/frontend/src/components/general/links/PaginationLink.tsx
@@ -1,0 +1,30 @@
+import { Link, LinkProps } from '@tanstack/react-router';
+import React from 'react';
+
+interface PaginationLinkProps {
+  color?: 'green-light' | 'grey' | 'green-dark'
+  link: LinkProps
+  label?: number
+  disabled?: boolean
+  icon?: React.ComponentType<React.SVGProps<SVGSVGElement>>
+}
+
+const PaginationLink: React.FC<PaginationLinkProps> = ({ color = 'grey', link, label, icon: Icon, disabled = false }) => {
+  const colorClasses = {
+    'green-light': 'bg-green-light/20 border border-green-light text-green-dark',
+    'green-dark': 'border border-green-dark text-green-dark aria-disabled:border-dark-200 aria-disabled:text-dark-400',
+    'grey': 'bg-dark-50 text-dark-600 hover:bg-dark-100',
+  };
+
+  return (
+    <Link
+      {...link}
+      disabled={disabled}
+      className={`flex items-center justify-center size-8 rounded-full font-semibold transition-color ease-in-out duration-300 ${colorClasses[color]}`}
+    >
+      {label && <span>{label}</span>}
+      {Icon && <Icon className="size-4" />}
+    </Link>
+  )};
+
+export default PaginationLink;

--- a/frontend/src/routes/_protected/treecluster/index.tsx
+++ b/frontend/src/routes/_protected/treecluster/index.tsx
@@ -18,13 +18,15 @@ import { treeClusterQuery } from '@/api/queries'
 const treeclusterFilterSchema = z.object({
   status: z.array(z.string()).optional(),
   region: z.array(z.string()).optional(),
+  page: z.number().default(1),
 })
 
 function Treecluster() {
   const { data: clustersRes } = useSuspenseQuery(treeClusterQuery())
+
   const [filteredData, setFilteredData] = useState({
     active: false,
-    data: clustersRes.data
+    data: clustersRes.data,
   })
   const { filters } = useFilter()
 
@@ -47,8 +49,8 @@ function Treecluster() {
   const handleFilter = () => {
     setFilteredData({
       active: true,
-      data: filterData
-    });
+      data: filterData,
+    })
   }
 
   return (
@@ -58,10 +60,13 @@ function Treecluster() {
           Auflistung der Bewässerungsgruppen
         </h1>
         <p className="mb-5">
-          Hier finden Sie eine Übersicht aller Bewässerungsgruppen.
-          Eine Bewässerungsgruppe besteht aus mehreren Bäumen, welche aufgrund ihrer Nähe und Standortbedinungen in einer Gruppe zusammengefasst wurden.
-          Die Ausstattung einzelner Bäume mit Sensoren erlaubt eine Gesamtaussage über den Bewässerungszustand der vollständigen Gruppe.
-          Die Auswertung der Daten aller Sensoren einer Bewässerungsgruppe liefert Handlungsempfehlungen für diese Gruppe.
+          Hier finden Sie eine Übersicht aller Bewässerungsgruppen. Eine
+          Bewässerungsgruppe besteht aus mehreren Bäumen, welche aufgrund ihrer
+          Nähe und Standortbedinungen in einer Gruppe zusammengefasst wurden.
+          Die Ausstattung einzelner Bäume mit Sensoren erlaubt eine
+          Gesamtaussage über den Bewässerungszustand der vollständigen Gruppe.
+          Die Auswertung der Daten aller Sensoren einer Bewässerungsgruppe
+          liefert Handlungsempfehlungen für diese Gruppe.
         </p>
         <ButtonLink
           icon={Plus}
@@ -71,12 +76,15 @@ function Treecluster() {
       </article>
 
       <section className="mt-10">
+        {/* TODO: Filter data from backend to work with pagination */}
         <div className="flex justify-end mb-6 lg:mb-10">
           <Dialog
             headline="Bewässerungsgruppen filtern"
             fullUrlPath={Route.fullPath}
             onApplyFilters={() => handleFilter()}
-            onResetFilters={() => setFilteredData({ active: false, data: clustersRes.data })}
+            onResetFilters={() =>
+              setFilteredData({ active: false, data: clustersRes.data })
+            }
           >
             <StatusFieldset />
             <RegionFieldset />
@@ -99,7 +107,15 @@ function Treecluster() {
               </p>
             }
           >
-            <TreeClusterList data={filteredData.active ? filteredData.data : clustersRes.data} />
+            <TreeClusterList
+              data={filteredData.active ? filteredData.data : clustersRes.data}
+            />
+            {/* TODO: Comment pagination in as soon as data is filtered through the backend */}
+            {/* {clustersRes.pagination && (
+              <Pagination 
+                pagination={clustersRes.pagination}
+              />
+            )} */}
           </ErrorBoundary>
         </Suspense>
       </section>
@@ -123,13 +139,14 @@ export const Route = createFileRoute('/_protected/treecluster/')({
   component: TreeclusterWithProvider,
   validateSearch: treeclusterFilterSchema,
 
-  loaderDeps: ({ search: { status, region } }) => ({
+  loaderDeps: ({ search: { status, region, page } }) => ({
     status: status || [],
     region: region || [],
+    page: page || 1,
   }),
 
-  loader: ({ deps: { status, region } }) => {
-    return { status, region }
+  loader: ({ deps: { status, region, page } }) => {
+    return { status, region, page }
   },
 })
 

--- a/frontend/src/routes/_protected/treecluster/index.tsx
+++ b/frontend/src/routes/_protected/treecluster/index.tsx
@@ -112,7 +112,8 @@ function Treecluster() {
             />
             {/* TODO: Comment pagination in as soon as data is filtered through the backend */}
             {/* {clustersRes.pagination && (
-              <Pagination 
+              <Pagination
+                url="/treecluster"
                 pagination={clustersRes.pagination}
               />
             )} */}


### PR DESCRIPTION
Close #380 

Test it with backend: https://github.com/green-ecolution/green-ecolution-backend/pull/378

Problem is that our current filter setup does not work with out pagination. We have to filter through the backend to make both functions work together. That is why the current pagination is commented out — but still it would be nice to add the general pagination component to the code base since we need the pagination also in other views.


Update the custerResponse to this and comment out the pagination component to test it:
```
  const search = useLoaderData({ from: '/_protected/treecluster/' })
  const { data: clustersRes } = useSuspenseQuery(
    treeClusterQuery({ page: search.page.toString(), limit: '10' })
  )
```

<img width="1219" alt="image" src="https://github.com/user-attachments/assets/8b77a4a0-f59b-4425-b92e-b5209ce60b2a" />
