### PR TITLE
fix: archive vehicles instead of deleting them

### DIFF
--- a/frontend/src/components/treecluster/DeleteSection.tsx
+++ b/frontend/src/components/treecluster/DeleteSection.tsx
@@ -8,12 +8,14 @@ import { LinkProps, useNavigate } from '@tanstack/react-router'
 interface DeleteSectionProps {
   mutationFn: () => Promise<unknown>
   entityName: string
+  type?: 'archive' | 'delete'
   redirectUrl: LinkProps
 }
 
 const DeleteSection: React.FC<DeleteSectionProps> = ({
   mutationFn,
   entityName,
+  type = 'delete',
   redirectUrl,
 }) => {
   const [isModalOpen, setIsModalOpen] = useState(false)
@@ -21,12 +23,14 @@ const DeleteSection: React.FC<DeleteSectionProps> = ({
   const [displayError, setDisplayError] = useState<string | null>(null)
   const showToast = useToast()
 
+  const actionText = type === 'archive' ? 'archiviert' : 'gelöscht'
+
   const { mutate, isError } = useMutation({
     mutationFn,
     onSuccess: () => {
       setIsModalOpen(false)
       navigate(redirectUrl)
-      showToast(`${entityName.charAt(0).toUpperCase()}${entityName.slice(1)} wurde erfolgreich gelöscht.`)
+      showToast(`${entityName.charAt(0).toUpperCase()}${entityName.slice(1)} wurde erfolgreich ${actionText}.`)
     },
     onError: (error: unknown) => {
       error instanceof Error
@@ -43,7 +47,7 @@ const DeleteSection: React.FC<DeleteSectionProps> = ({
         onClick={() => setIsModalOpen(true)}
         className="mt-10 group flex items-center gap-x-2 text-red font-medium text-base mb-4"
       >
-        Löschen
+        {type === 'archive' ? 'Archivieren' : 'Löschen'}
         <MoveRight className="w-4 h-4 transition-all ease-in-out duration-300 group-hover:translate-x-1" />
       </button>
 
@@ -54,9 +58,9 @@ const DeleteSection: React.FC<DeleteSectionProps> = ({
       )}
 
       <Modal
-        title={`Soll ${entityName} wirklich gelöscht werden?`}
-        description={`Sobald ${entityName} gelöscht wurde, können die Daten nicht wieder hergestellt werden.`}
-        confirmText="Wirklich löschen"
+        title={`Soll ${entityName} wirklich ${actionText} werden?`}
+        description={`Sobald ${entityName} ${actionText} wurde, können die Daten nicht wieder hergestellt werden.`}
+        confirmText="Bestätigen"
         onConfirm={() => mutate()}
         onCancel={() => setIsModalOpen(false)}
         isOpen={isModalOpen}

--- a/frontend/src/components/vehicle/VehicleUpdate.tsx
+++ b/frontend/src/components/vehicle/VehicleUpdate.tsx
@@ -49,8 +49,8 @@ const VehicleUpdate = ({
     mutate({...data})
   }
 
-  const handleDeleteVehicle = () => {
-    return vehicleApi.deleteVehicle({
+  const handleArchiveVehicle = () => {
+    return vehicleApi.archiveVehicle({
       id: String(vehicleId),
     })
   }
@@ -84,7 +84,8 @@ const VehicleUpdate = ({
 
       <Suspense fallback={<LoadingInfo label="Das Fahrzeug wird gelöscht" />}>
         <DeleteSection
-          mutationFn={handleDeleteVehicle}
+          mutationFn={handleArchiveVehicle}
+          type="archive"
           entityName="das Fahrzeug"
           redirectUrl={{ to: '/vehicles' }}
         />

--- a/frontend/src/components/watering-plan/TabGeneralData.tsx
+++ b/frontend/src/components/watering-plan/TabGeneralData.tsx
@@ -22,6 +22,8 @@ const TabGeneralData: React.FC<TabGeneralDataProps> = ({ wateringPlan }) => {
   const updatedDate = wateringPlan?.updatedAt
     ? format(new Date(wateringPlan.updatedAt), 'dd.MM.yyyy')
     : 'Keine Angabe'
+  
+  console.log(wateringPlan.transporter.archivedAt)
 
   const wateringPlanData = [
     {
@@ -43,13 +45,13 @@ const TabGeneralData: React.FC<TabGeneralDataProps> = ({ wateringPlan }) => {
     {
       label: 'Transporter',
       value: wateringPlan.transporter
-        ? wateringPlan.transporter.numberPlate
+        ? `${wateringPlan.transporter.numberPlate}${wateringPlan.transporter.archivedAt ? ' (Archiviert)' : ''}`
         : 'Keine Angabe',
     },
     {
       label: 'Zusätzlicher Anhänger',
       value: wateringPlan.trailer
-        ? wateringPlan.trailer.numberPlate
+        ? `${wateringPlan.trailer.numberPlate}${wateringPlan.trailer.archivedAt ? ' (Archiviert)' : ''}`
         : 'Keine Angabe',
     },
     {

--- a/frontend/src/components/watering-plan/TabGeneralData.tsx
+++ b/frontend/src/components/watering-plan/TabGeneralData.tsx
@@ -22,8 +22,6 @@ const TabGeneralData: React.FC<TabGeneralDataProps> = ({ wateringPlan }) => {
   const updatedDate = wateringPlan?.updatedAt
     ? format(new Date(wateringPlan.updatedAt), 'dd.MM.yyyy')
     : 'Keine Angabe'
-  
-  console.log(wateringPlan.transporter.archivedAt)
 
   const wateringPlanData = [
     {


### PR DESCRIPTION
Currently the `archived_at` value in the vehicle watering plan response is not empty. That's why every vehicle is shown as `(Archiviert)`. That has to be updated in the backend

https://github.com/green-ecolution/green-ecolution-backend/issues/437